### PR TITLE
Update from update/Mixaster995/test-actions-3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/Mixaster995/test-actions-4
 
 go 1.16
 
-require github.com/Mixaster995/test-actions-3 v0.0.0-20210728054754-7c5328cb5819
+require (
+	github.com/Mixaster995/test-actions-2 v0.0.0-20210730025333-8f63e52828bf // indirect
+	github.com/Mixaster995/test-actions-3 v0.0.0-20210730030236-dc32b6554cd8
+)

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,11 @@
-github.com/Mixaster995/test-actions v0.0.0-20210728041429-0a03bc042c0a h1:dUoWGMoJhp2fZeJeyRzODPChmIBoI2WjaGc7PJpQr8o=
 github.com/Mixaster995/test-actions v0.0.0-20210728041429-0a03bc042c0a/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
-github.com/Mixaster995/test-actions-2 v0.0.0-20210728041535-b582371b8108 h1:OchQBZtydJTYnOHnxbDyEX801r0ipchfpaaPpE7JjSI=
+github.com/Mixaster995/test-actions v0.0.0-20210728084632-d9bb43edb245 h1:3W5CP2w0FX2jLTh7gt8sGt5b/QwX7XXmBvXcaTBsr+Y=
+github.com/Mixaster995/test-actions v0.0.0-20210728084632-d9bb43edb245/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
 github.com/Mixaster995/test-actions-2 v0.0.0-20210728041535-b582371b8108/go.mod h1:iqbiMKUeI1lBAjBS5JilYKAQFvUK29/Hq6Yw34ouNIg=
-github.com/Mixaster995/test-actions-3 v0.0.0-20210728054754-7c5328cb5819 h1:iQK7s1lxjzSYbb/dx+ux/KHoZ9+TfHQ5mjolK0c54GU=
-github.com/Mixaster995/test-actions-3 v0.0.0-20210728054754-7c5328cb5819/go.mod h1:/At5mMvkNlUEEiO5sF6/2Ult5OJT49IF8QKoytzZwdY=
+github.com/Mixaster995/test-actions-2 v0.0.0-20210730025333-8f63e52828bf h1:ypTGX9hav6e091ZZh3hRB9Wbm0X71oY9mRppvZoMVsg=
+github.com/Mixaster995/test-actions-2 v0.0.0-20210730025333-8f63e52828bf/go.mod h1:BajdudSZ5YdrzDdXN7xDhNPMX6foDazksCmTUNGkiCs=
+github.com/Mixaster995/test-actions-3 v0.0.0-20210730030236-dc32b6554cd8 h1:Rnj3uqSoQcrgYjMf21ZB1WqGwD9WlnjqWOVydTb0b2I=
+github.com/Mixaster995/test-actions-3 v0.0.0-20210730030236-dc32b6554cd8/go.mod h1:/At5mMvkNlUEEiO5sF6/2Ult5OJT49IF8QKoytzZwdY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Date: 2021-07-30 03:03:08 +0000
- Update go.mod and go.sum to latest version from Mixaster995/test-actions-3@main
PR link: https://github.com/Mixaster995/test-actions-3/pull/
Commit: dc32b65
Author: Mikhail Avramenko
Date: 2021-07-30 10:02:36 +0700
Message:
  - asdf