### PR TITLE
Update from update/Mixaster995/test-actions-3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Mixaster995/test-actions-4
 
 go 1.16
 
-require github.com/Mixaster995/test-actions-3 v0.0.0-20210730035841-f4f45471792e
+require github.com/Mixaster995/test-actions-3 v0.0.0-20210730041627-688fa4d0f90a

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Mixaster995/test-actions v0.0.0-20210730035240-0c12cc470fff h1:i5819I
 github.com/Mixaster995/test-actions v0.0.0-20210730035240-0c12cc470fff/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
 github.com/Mixaster995/test-actions-2 v0.0.0-20210730035346-d4055d5b8f91 h1:Y0eFCMOVHRgdfcadOzlYhYvft3eOfPHFLP89MVSdCo0=
 github.com/Mixaster995/test-actions-2 v0.0.0-20210730035346-d4055d5b8f91/go.mod h1:KnalHNZdioQdvd6x7M65DMjp2PdpbaxShyzdzgf6Njo=
-github.com/Mixaster995/test-actions-3 v0.0.0-20210730035841-f4f45471792e h1:SioSlCpooYdB/Fc6DhcuWIdbZP64w/QrkZHBSCp4t4o=
-github.com/Mixaster995/test-actions-3 v0.0.0-20210730035841-f4f45471792e/go.mod h1:PW1vz6U5o+Nq6YcISSkdCZboy3MJFjNmD+fTF7qRgeo=
+github.com/Mixaster995/test-actions-3 v0.0.0-20210730041627-688fa4d0f90a h1:qnnYH2+9X2+kJLb+QHn+azd8QM73qscP16k4kCou/Bs=
+github.com/Mixaster995/test-actions-3 v0.0.0-20210730041627-688fa4d0f90a/go.mod h1:PW1vz6U5o+Nq6YcISSkdCZboy3MJFjNmD+fTF7qRgeo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Update go.mod and go.sum to latest version from Mixaster995/test-actions-3@main
PR link: https://github.com/Mixaster995/test-actions-3/pull/
Commit: 688fa4d
Author: Mikhail Avramenko
Date: 2021-07-30 11:16:27 +0700
Message:
  - qwer